### PR TITLE
Fix preview rendering and Word export pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@ $$"></textarea>
     
     <!-- 首先加载docx.js库，然后加载 MathML 转换器和应用逻辑 -->
     <script src="docx.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script type="module">
         import { mml2omml } from './mathml2omml.js';
         window.mml2omml = mml2omml;


### PR DESCRIPTION
## Summary
- replace the broken front-end logic with a robust Markdown previewer and math-aware Word exporter
- load Marked from CDN to provide full Markdown rendering support in the preview

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68ccc717dacc832688f507bd7cd7d91e