### PR TITLE
Escape MathML text nodes when generating OMML

### DIFF
--- a/mathml2omml.js
+++ b/mathml2omml.js
@@ -722,10 +722,29 @@ function attrString(attribs) {
   return ` ${buff.join(' ')}`
 }
 
+function escapeXmlText(text) {
+  if (!text) {
+    return ''
+  }
+
+  return text.replace(/[&<>]/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;'
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      default:
+        return char
+    }
+  })
+}
+
 function stringify(buff, doc) {
   switch (doc.type) {
     case 'text':
-      return buff + doc.data
+      return buff + escapeXmlText(doc.data)
     case 'tag': {
       const voidElement =
         doc.voidElement || (!doc.children.length && doc.attribs['xml:space'] !== 'preserve')


### PR DESCRIPTION
## Summary
- escape MathML text node content when serializing OMML
- ensure operators such as less-than render properly in generated Word documents

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce616bc2808326a9ae9601cd0f9a19